### PR TITLE
Authn/authz for POLIS convert route

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -14,6 +14,7 @@ touch .env
   4.  EMAIL_FROM={the email to send the verification link}
   5.  NEXT_PUBLIC_POLIS_SURVEYS='[{"id": "{yourSurveyID1}", "title": "{yourSurveyTitle1}", "description", "{yourSurveyDescription1}"}, ...]'
   6.  NEXT_PUBLIC_SEARCH_API='{your ArcGIS Search Api Key}'
+  7.  AUTHORIZED_POLIS_CONVERT_EMAILS_FILE={path to file that contains a list of email addresses (one per line) whose users are authorized to export POLIS data}
 
 ```
 npx prisma db push

--- a/src/pages/api/export.js
+++ b/src/pages/api/export.js
@@ -5,6 +5,8 @@ import multiparty from "multiparty";
 import ObjectsToCsv from "objects-to-csv";
 import csv from "csv-parser";
 import fs from "fs";
+import { authOptions } from './../../server/auth'
+import { getServerSession } from "next-auth/next"
 
 import { prisma } from "../../server/db";
 
@@ -14,6 +16,9 @@ export const config = {
     bodyParser: false,
   },
 };
+
+export const authorizedEmails = fs.readFileSync(process.env.AUTHORIZED_POLIS_CONVERT_EMAILS_FILE, 'utf8').split(/\r?\n/);
+console.log("Emails authorized to export POLIS data: " + authorizedEmails);
 
 function handleError(error, res) {
   console.error(error.stack);
@@ -26,7 +31,18 @@ const handler = nc({
     res.status(404).end("Page is not found");
   },
 }).post(async (req, res) => {
-  // TODO - add authentication / authorization so that only admins can access this, as it extracts census tract and zip code data for users
+
+  const sessionData = await getServerSession(req, res, authOptions);
+
+  if (!sessionData) {
+    res.status(401).end("Not authenticated; please log in on homepage.");
+    return;
+  }
+  const email = sessionData.user.email;
+  if (!authorizedEmails.includes(email)) {
+    res.status(403).end(email + ", you are not authorized to export Pol.is data.");
+    return;
+  }
 
   const form = new multiparty.Form();
 

--- a/src/pages/api/export.js
+++ b/src/pages/api/export.js
@@ -22,7 +22,7 @@ console.log("Emails authorized to export POLIS data: " + authorizedEmails);
 
 function handleError(error, res) {
   console.error(error.stack);
-  res.status(500).end("Sorry, an error occured while processing a Pol.is export. The error has been logged for admistrators.d");
+  res.status(500).end("Sorry, an error occured while processing a Pol.is export. The error has been logged for admistrators.");
 }
 
 const handler = nc({

--- a/src/pages/polisconvert.tsx
+++ b/src/pages/polisconvert.tsx
@@ -1,10 +1,16 @@
 // page for serving form for accepting raw Pol.is participant votes data and returning the data augmented with user zip code and census tract data
 import { type NextPage } from "next";
 
+import { useSession } from "next-auth/react";
+
 const PolisConvert: NextPage = () => {
+
+  const { data: sessionData } = useSession();
+
   return (
     <div>
       <h2>Polis Data Conversion</h2>
+      {sessionData ? "You are signed in" : "You are not signed in"}<br />
       <form method="post" action="/api/export" encType="multipart/form-data">
         <input type="file" id="polisdata" name="polisdata" />
         <input type="submit" />

--- a/src/pages/polisconvert.tsx
+++ b/src/pages/polisconvert.tsx
@@ -11,6 +11,7 @@ const PolisConvert: NextPage = () => {
     <div>
       <h2>Polis Data Conversion</h2>
       {sessionData ? "You are signed in" : "You are not signed in"}<br />
+      Please select a participant-votes.csv file to upload, then click submit.<br />
       <form method="post" action="/api/export" encType="multipart/form-data">
         <input type="file" id="polisdata" name="polisdata" />
         <input type="submit" />


### PR DESCRIPTION
Fixes #77 

The user attempting to export data through `/polisconvert` must be logged in, and their email address must match one of the emails listed in the `AUTHORIZED_POLIS_CONVERT_EMAILS_FILE` referenced in the `.env.local` file.